### PR TITLE
Specified user-agent of the electron browser.

### DIFF
--- a/lib/quantal-api.js
+++ b/lib/quantal-api.js
@@ -210,7 +210,7 @@ class QuantalApi {
             const win = new BrowserWindow(browserWindowParams || {'use-content-size': true});
             win.setMenu(null)
 
-            win.loadURL(`${this._apiUrl}/authentication/app`)
+            win.loadURL(`${this._apiUrl}/authentication/app`, {userAgent: 'Chrome'})
 
             win.on('closed', () => {
                 reject({ name: QuantalError.CONNECT_WINDOW_CLOSED, message: 'User closed the connexion window' })


### PR DESCRIPTION
A fresh installation and login via the plug-in is not able to work due to some changes made on Google's side with browser compatibility which affected the functionality of the plug-in. Specifying the user-agent fixed it.